### PR TITLE
CI: add `permissions`

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -5,9 +5,12 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node.js


### PR DESCRIPTION
Recently, GitHub change the default value of `permissions`.

- [GitHub Actions - Updating the default GITHUB_TOKEN permissions to read-only | GitHub Changelog](https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/)

We need to add `permissions` to workflow.

fix #5 